### PR TITLE
Add script to fetch Latvia music events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Latvia Music Events Fetcher
+
+This repository contains a simple Python script for retrieving upcoming music events in Latvia for the next weekend using the Ticketmaster Discovery API.
+
+## Requirements
+- Python 3.10+
+- `requests` package
+- A Ticketmaster API key
+
+## Setup
+1. Install dependencies:
+   ```bash
+   pip install requests
+   ```
+2. Export your Ticketmaster API key as an environment variable:
+   ```bash
+   export TICKETMASTER_API_KEY=YOUR_KEY_HERE
+   ```
+
+## Usage
+Run the script:
+```bash
+python fetch_latvia_music_events.py
+```
+The script prints event names, start dates, and URLs for the upcoming weekend.

--- a/fetch_latvia_music_events.py
+++ b/fetch_latvia_music_events.py
@@ -1,0 +1,39 @@
+import os
+import requests
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+API_KEY = os.getenv('TICKETMASTER_API_KEY')
+if not API_KEY:
+    raise SystemExit("Please set the TICKETMASTER_API_KEY environment variable")
+
+def upcoming_weekend_range(tz=ZoneInfo('Europe/Riga')):
+    today = datetime.now(tz).date()
+    days_until_friday = (4 - today.weekday()) % 7
+    friday = datetime.combine(today + timedelta(days=days_until_friday), datetime.min.time(), tz)
+    sunday = friday + timedelta(days=2, hours=23, minutes=59, seconds=59)
+    return friday.astimezone(ZoneInfo('UTC')), sunday.astimezone(ZoneInfo('UTC'))
+
+def fetch_events():
+    start, end = upcoming_weekend_range()
+    url = 'https://app.ticketmaster.com/discovery/v2/events.json'
+    params = {
+        'apikey': API_KEY,
+        'countryCode': 'LV',
+        'classificationName': 'music',
+        'startDateTime': start.isoformat().replace('+00:00', 'Z'),
+        'endDateTime': end.isoformat().replace('+00:00', 'Z'),
+        'size': 20
+    }
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    events = data.get('_embedded', {}).get('events', [])
+    for e in events:
+        name = e.get('name')
+        date = e.get('dates', {}).get('start', {}).get('dateTime')
+        link = e.get('url')
+        print(f"{name} | {date} | {link}")
+
+if __name__ == '__main__':
+    fetch_events()


### PR DESCRIPTION
## Summary
- add a Python script using Ticketmaster API to fetch weekend music events in Latvia
- document setup and usage in README

## Testing
- `pip install requests`
- `python fetch_latvia_music_events.py` *(fails: `Please set the TICKETMASTER_API_KEY environment variable`)*
- `python fetch_latvia_music_events.py` with dummy key *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_684302f6d774832dabedb81f3bad9464